### PR TITLE
Performance improvement for SVG indentation.

### DIFF
--- a/src/backend/svg.rs
+++ b/src/backend/svg.rs
@@ -32,8 +32,12 @@ impl SvgBackend {
 
     pub fn render_scene(&self, scene: &Scene) -> String {
         let nl = if self.pretty { "\n" } else { "" };
-        let indent = |d: usize| -> String {
-            if self.pretty { "  ".repeat(d) } else { String::new() }
+        let indent = |svg: &mut String, depth: usize| {
+            if self.pretty {
+                for _ in 0..depth {
+                    svg.push_str("  ");
+                }
+            }
         };
 
         // create svg with width and height
@@ -60,7 +64,7 @@ impl SvgBackend {
         // Add a background rect if specified: .with_background(Some("white"))
         // "none" for transparent
         if let Some(color) = &scene.background_color {
-            svg.push_str(&indent(1));
+            indent(&mut svg, 1);
             svg.push_str(&format!(
                 r#"<rect width="100%" height="100%" fill="{color}" />"#
             ));
@@ -69,7 +73,7 @@ impl SvgBackend {
 
         // Emit any SVG defs (e.g. linearGradients for Sankey ribbons)
         if !scene.defs.is_empty() {
-            svg.push_str(&indent(1));
+            indent(&mut svg, 1);
             svg.push_str("<defs>");
             for d in &scene.defs {
                 svg.push_str(d);
@@ -83,7 +87,7 @@ impl SvgBackend {
         for elem in &scene.elements {
             match elem {
                 Primitive::Circle { cx, cy, r, fill } => {
-                    svg.push_str(&indent(depth));
+                    indent(&mut svg, depth);
                     svg.push_str(&format!(
                         r#"<circle cx="{cx}" cy="{cy}" r="{r}" fill="{fill}" />"#,
                     ));
@@ -105,14 +109,14 @@ impl SvgBackend {
                     let bold_str = if *bold { r#" font-weight="bold""# } else { "" };
 
                     let escaped = escape_xml(content);
-                    svg.push_str(&indent(depth));
+                    indent(&mut svg, depth);
                     svg.push_str(&format!(
                         r#"<text x="{x}" y="{y}" font-size="{size}" text-anchor="{anchor_str}"{bold_str}{transform}>{escaped}</text>"#
                     ));
                     svg.push_str(nl);
                 }
                 Primitive::Line { x1, y1, x2, y2, stroke, stroke_width, stroke_dasharray } => {
-                    svg.push_str(&indent(depth));
+                    indent(&mut svg, depth);
                     svg.push_str(&format!(
                         r#"<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{stroke}" stroke-width="{stroke_width}""#,
                     ));
@@ -123,7 +127,7 @@ impl SvgBackend {
                     svg.push_str(nl);
                 }
                 Primitive::Path { d, fill, stroke, stroke_width, opacity, stroke_dasharray } => {
-                    svg.push_str(&indent(depth));
+                    indent(&mut svg, depth);
                     svg.push_str(&format!(
                         r#"<path d="{d}" stroke="{stroke}" stroke-width="{stroke_width}""#
                     ));
@@ -147,7 +151,7 @@ impl SvgBackend {
                     svg.push_str(nl);
                 }
                 Primitive::GroupStart { transform } => {
-                    svg.push_str(&indent(depth));
+                    indent(&mut svg, depth);
                     svg.push_str("<g");
                     if let Some(t) = transform {
                         svg.push_str(&format!(r#" transform="{t}""#));
@@ -158,12 +162,12 @@ impl SvgBackend {
                 }
                 Primitive::GroupEnd => {
                     depth -= 1;
-                    svg.push_str(&indent(depth));
+                    indent(&mut svg, depth);
                     svg.push_str("</g>");
                     svg.push_str(nl);
                 }
                 Primitive::Rect { x, y, width, height, fill, stroke, stroke_width, opacity} => {
-                    svg.push_str(&indent(depth));
+                    indent(&mut svg, depth);
                     svg.push_str(&format!(
                         r#"<rect x="{x}" y="{y}" width="{width}" height="{height}" fill="{fill}""#
                     ));


### PR DESCRIPTION
Current code
  > if self.pretty { "  ".repeat(d) } else { String::new() }
will allocate a new String buffer every time this closure is called.

The new code
  > for _ in 0..depth {
  >   svg.push_str("  ");
  > }
will write directly to the output (no allocations done).

Small perf. increase for a few extra lines.