### PR TITLE
Fix data-max tick overprinting the top decade on log/count colorbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Colorbar tick overprint on log/count colorbars** — the log-scale colorbar (hexbin and 2-D histogram with log colouring) appends a tick at the exact data maximum in addition to the nearest power-of-ten tick. In log space the two can sit a fraction of a decade apart, so their labels overprinted at the top of the bar. Adjacent colorbar tick labels closer than one label height are now thinned — entries are drawn bottom-to-top and the first of any too-close pair is kept, so the round decade tick survives and the redundant data-max label is dropped only when it would actually collide.
+
+---
+
 ## [0.3.0] — 2026-06-19
 
 ### Added

--- a/src/render/render.rs
+++ b/src/render/render.rs
@@ -7672,12 +7672,27 @@ fn add_colorbar_at(
             .collect();
         auto_ticks.as_slice()
     };
+
+    // Minimum vertical spacing between adjacent tick labels. Count/log colorbars
+    // append a tick at the exact data maximum on top of the nearest power-of-ten
+    // tick; in log space the two can sit a fraction of a decade apart so their
+    // labels overprint at the top of the bar. Entries arrive in ascending value
+    // order (drawn bottom→top), so keeping the first of any too-close pair
+    // preserves the round decade tick and drops the redundant data-max label.
+    let min_label_gap = computed.tick_size as f64;
+    let mut last_drawn_y: Option<f64> = None;
     for (pos, label) in tick_entries {
         if *pos < info.min_value || *pos > info.max_value {
             continue;
         }
         let frac = (pos - info.min_value) / range;
         let y = bar_y + bar_height - frac * bar_height; // invert: high values at top
+        if let Some(prev_y) = last_drawn_y {
+            if (y - prev_y).abs() < min_label_gap {
+                continue;
+            }
+        }
+        last_drawn_y = Some(y);
 
         // tick mark
         scene.add(Primitive::Line {

--- a/tests/colorbar_tick_spacing.rs
+++ b/tests/colorbar_tick_spacing.rs
@@ -1,0 +1,67 @@
+//! Colorbar tick spacing: the log/count colorbar appends a tick at the exact data
+//! maximum on top of the nearest power-of-ten tick. When the two sit within a label
+//! height of each other their labels overprint, so the renderer drops the redundant
+//! data-max label while keeping it when it is clearly clear of the decade tick.
+
+use kuva::backend::svg::SvgBackend;
+use kuva::plot::hexbin::HexbinPlot;
+use kuva::render::{layout::Layout, plots::Plot, render::render_multiple};
+
+fn render_svg(plots: Vec<Plot>, layout: Layout) -> String {
+    SvgBackend.render_scene(&render_multiple(plots, layout))
+}
+
+/// One dense hex (all points share a coordinate) plus a handful of far-apart
+/// singletons. The dense hex sets `v_max`; the singletons pin `v_min` at 1, so the
+/// log colorbar labels run 1, 10, 100, … and append `v_max - v_min` at the top.
+fn make_hexbin_with_peak(peak_count: usize) -> Vec<Plot> {
+    let mut x = vec![2.5_f64; peak_count];
+    let mut y = vec![2.5_f64; peak_count];
+    for (sx, sy) in [(0.2, 0.2), (4.8, 0.3), (0.3, 4.7), (4.6, 4.8), (4.9, 2.5), (0.1, 2.6)] {
+        x.push(sx);
+        y.push(sy);
+    }
+    vec![Plot::Hexbin(
+        HexbinPlot::new().with_data(x, y).with_log_color(true),
+    )]
+}
+
+#[test]
+fn test_data_max_label_suppressed_when_adjacent_to_decade() {
+    // peak 112 → displayed max = 111, one notch above the 100 decade tick.
+    let plots = make_hexbin_with_peak(112);
+    let layout = Layout::auto_from_plots(&plots).with_title("Hexbin peak 112");
+    let svg = render_svg(plots, layout);
+    std::fs::write("test_outputs/colorbar_tick_spacing_suppressed.svg", &svg).unwrap();
+
+    assert!(
+        svg.contains(">100</text>"),
+        "the 100 decade tick must remain labelled"
+    );
+    assert!(
+        !svg.contains(">111</text>"),
+        "the data-max tick (111) overprints the 100 decade and must be dropped"
+    );
+}
+
+/// Guards against *over*-suppression: a data max that is clearly clear of the decade
+/// must not be thinned. (The fix direction itself is covered by the suppressed test —
+/// this one passes with or without thinning, but fails if the gap threshold is ever
+/// made aggressive enough to drop a well-separated tick.)
+#[test]
+fn test_data_max_label_kept_when_clear_of_decade() {
+    // peak 300 → displayed max = 299, ~half a decade above 100: no overprint.
+    let plots = make_hexbin_with_peak(300);
+    let layout = Layout::auto_from_plots(&plots).with_title("Hexbin peak 300");
+    let svg = render_svg(plots, layout);
+    std::fs::write("test_outputs/colorbar_tick_spacing_kept.svg", &svg).unwrap();
+
+    assert!(
+        svg.contains(">100</text>"),
+        "the 100 decade tick must remain labelled"
+    );
+    assert!(
+        svg.contains(">299</text>"),
+        "the data-max tick (299) is clear of the decade and must be kept"
+    );
+}

--- a/tests/colorbar_tick_spacing.rs
+++ b/tests/colorbar_tick_spacing.rs
@@ -3,6 +3,8 @@
 //! height of each other their labels overprint, so the renderer drops the redundant
 //! data-max label while keeping it when it is clearly clear of the decade tick.
 
+mod common;
+
 use kuva::backend::svg::SvgBackend;
 use kuva::plot::hexbin::HexbinPlot;
 use kuva::render::{layout::Layout, plots::Plot, render::render_multiple};
@@ -32,7 +34,7 @@ fn test_data_max_label_suppressed_when_adjacent_to_decade() {
     let plots = make_hexbin_with_peak(112);
     let layout = Layout::auto_from_plots(&plots).with_title("Hexbin peak 112");
     let svg = render_svg(plots, layout);
-    std::fs::write("test_outputs/colorbar_tick_spacing_suppressed.svg", &svg).unwrap();
+    common::write_test_output("test_outputs/colorbar_tick_spacing_suppressed.svg", &svg).unwrap();
 
     assert!(
         svg.contains(">100</text>"),
@@ -54,7 +56,7 @@ fn test_data_max_label_kept_when_clear_of_decade() {
     let plots = make_hexbin_with_peak(300);
     let layout = Layout::auto_from_plots(&plots).with_title("Hexbin peak 300");
     let svg = render_svg(plots, layout);
-    std::fs::write("test_outputs/colorbar_tick_spacing_kept.svg", &svg).unwrap();
+    common::write_test_output("test_outputs/colorbar_tick_spacing_kept.svg", &svg).unwrap();
 
     assert!(
         svg.contains(">100</text>"),


### PR DESCRIPTION
## Problem

The log-scale colorbar used by `HexbinPlot` (and `Histogram2D` with log colouring) places a tick at the **exact data maximum** *in addition to* the nearest power-of-ten tick. In log space the two can sit a fraction of a decade apart (e.g. a max of 111,510 vs the 100,000 decade is ~0.05 decades), so the two labels overprint at the top of the bar.

## Fix

Thin adjacent colorbar tick labels in `add_colorbar_at`. Tick entries are drawn bottom-to-top (ascending value), and the first of any pair closer than one label height (`tick_size`) is kept. This preserves the round decade tick and drops the redundant data-max label **only** when it would actually collide — a data max clearly clear of the decade (e.g. ~half a decade above) is still labelled.

The thinning lives in the generic colorbar tick loop, so in practice only the log/count colorbars (the only ones that append an irregular max tick) are affected; well-spaced linear ticks never trip the gap.

## Tests

`tests/colorbar_tick_spacing.rs`:
- `test_data_max_label_suppressed_when_adjacent_to_decade` — peak 112 → displayed max 111 is dropped, `100` decade kept.
- `test_data_max_label_kept_when_clear_of_decade` — peak 300 → displayed max 299 is kept alongside `100` (a no-over-suppression guard).

`cargo test --features cli,full` and `cargo clippy --features cli,full -- -D warnings` pass.

## Design note

This is narrower than the opt-in `AxisLabelOverlap` mechanism (PR #82): two colorbar tick labels within one label-height is genuine overprint, never desired, so the thinning is collision-gated and always-on rather than a discretionary crowding control. Happy to rework it behind a builder flag if you'd prefer it aligned with `AxisLabelOverlap`.