### PR TITLE
Honor with_colorbar_tick_format on log/count colorbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Log/count colorbars now honour `Layout::with_colorbar_tick_format`** — the log-scale colorbar used by `HexbinPlot` and `Histogram2D` (with log colouring) generated its own hard-coded power-of-ten integer labels and ignored the configured colorbar tick format, so a custom formatter (e.g. an SI formatter producing `1k`, `10k`, `100k`) had no effect. `ColorBarInfo` gains a `tick_values` field carrying `(position, value)` pairs; the value is formatted through `with_colorbar_tick_format` at render time, matching how the linear colorbar already behaved. Default (`TickFormat::Auto`) output is unchanged for integer count labels.
+
+---
+
 ## [0.3.0] — 2026-06-19
 
 ### Added

--- a/src/plot/calendar.rs
+++ b/src/plot/calendar.rs
@@ -458,6 +458,7 @@ impl CalendarPlot {
             max_value: v_max,
             label,
             tick_labels: None,
+            tick_values: None,
         })
     }
 }

--- a/src/plot/legend.rs
+++ b/src/plot/legend.rs
@@ -87,4 +87,12 @@ pub struct ColorBarInfo {
     /// When set, overrides auto-generated ticks. Each entry is `(position, label)` where
     /// `position` is in `[min_value, max_value]` space.
     pub tick_labels: Option<Vec<(f64, String)>>,
+    /// When set, overrides auto-generated ticks *and* `tick_labels`. Each entry is
+    /// `(position, value)` where `position` is in `[min_value, max_value]` space and
+    /// `value` is the data value to display; the value is formatted through the
+    /// layout's colorbar tick format at render time. Use this (rather than
+    /// `tick_labels`) when ticks should honour `Layout::with_colorbar_tick_format`,
+    /// e.g. log/count colorbars where positions live in log space but labels are raw
+    /// counts.
+    pub tick_values: Option<Vec<(f64, f64)>>,
 }

--- a/src/render/plots.rs
+++ b/src/render/plots.rs
@@ -482,6 +482,7 @@ pub(crate) fn colorbar_linear(
         max_value: max,
         label,
         tick_labels: None,
+        tick_values: None,
     })
 }
 
@@ -1598,9 +1599,11 @@ impl Plot {
                 if log_scale {
                     // Colorbar in log₁₀ space: ticks at integer powers of 10 labelled
                     // with the actual count value so users can read off "this color = N cells".
+                    // Positions live in log space; the raw counts are supplied as values so
+                    // `add_colorbar_at` formats them through `with_colorbar_tick_format`.
                     let log_max = (max_count + 1.0).log10();
-                    let tick_labels: Vec<(f64, String)> = {
-                        let mut v = vec![(0.0_f64, "0".to_string())];
+                    let tick_values: Vec<(f64, f64)> = {
+                        let mut v = vec![(0.0_f64, 0.0_f64)];
                         let mut k = 0u32;
                         loop {
                             let count = 10_f64.powi(k as i32);
@@ -1608,11 +1611,11 @@ impl Plot {
                                 break;
                             }
                             let pos = (count + 1.0).log10();
-                            v.push((pos, format!("{}", count as u64)));
+                            v.push((pos, count));
                             k += 1;
                         }
                         // Always include max_count at the top
-                        v.push((log_max, format!("{}", max_count as u64)));
+                        v.push((log_max, max_count));
                         v.dedup_by(|a, b| (a.0 - b.0).abs() < 1e-9);
                         v
                     };
@@ -1624,7 +1627,8 @@ impl Plot {
                         min_value: 0.0,
                         max_value: log_max,
                         label: Some("log\u{2081}\u{2080}(Count + 1)".to_string()),
-                        tick_labels: Some(tick_labels),
+                        tick_labels: None,
+                        tick_values: Some(tick_values),
                     })
                 } else {
                     Some(ColorBarInfo {
@@ -1633,6 +1637,7 @@ impl Plot {
                         max_value: max_count,
                         label: Some("Count".to_string()),
                         tick_labels: None,
+                        tick_values: None,
                     })
                 }
             }

--- a/src/render/render.rs
+++ b/src/render/render.rs
@@ -7658,19 +7658,27 @@ fn add_colorbar_at(
         opacity: None,
     });
 
-    // Tick marks and labels — use custom tick_labels if provided, else auto-generate
+    // Tick marks and labels. Precedence: `tick_values` (positions + raw values,
+    // formatted here through the colorbar tick format) > `tick_labels` (pre-formatted
+    // strings) > auto-generated ticks.
     let range = info.max_value - info.min_value;
-    let auto_ticks: Vec<(f64, String)>;
-    let tick_entries: &[(f64, String)] = if let Some(ref tl) = info.tick_labels {
+    let owned_ticks: Vec<(f64, String)>;
+    let tick_entries: &[(f64, String)] = if let Some(ref tv) = info.tick_values {
+        owned_ticks = tv
+            .iter()
+            .map(|&(pos, value)| (pos, computed.colorbar_tick_format.format(value)))
+            .collect();
+        owned_ticks.as_slice()
+    } else if let Some(ref tl) = info.tick_labels {
         tl.as_slice()
     } else {
         let raw = render_utils::generate_ticks(info.min_value, info.max_value, 5);
-        auto_ticks = raw
+        owned_ticks = raw
             .into_iter()
             .filter(|t| *t >= info.min_value && *t <= info.max_value)
             .map(|t| (t, computed.colorbar_tick_format.format(t)))
             .collect();
-        auto_ticks.as_slice()
+        owned_ticks.as_slice()
     };
     for (pos, label) in tick_entries {
         if *pos < info.min_value || *pos > info.max_value {
@@ -9817,6 +9825,7 @@ fn add_dice_legends(dp: &DicePlot, scene: &mut Scene, computed: &ComputedLayout)
             max_value: fill_max,
             label: dp.fill_legend_label.clone(),
             tick_labels: None,
+            tick_values: None,
         };
         let bar_x = computed.width - computed.colorbar_x_inset;
         // If the remaining height after stacking the other legend boxes is less than
@@ -17689,25 +17698,28 @@ fn add_hexbin_colorbar(hb: &HexbinPlot, scene: &mut Scene, computed: &ComputedLa
         });
 
     type MapFn = Arc<dyn Fn(f64) -> String + Send + Sync>;
+    // For log colouring the ticks live in log space (`position`) but are labelled with
+    // the raw count (`value`); supplying `(position, value)` pairs lets `add_colorbar_at`
+    // format the labels through `Layout::with_colorbar_tick_format`.
     #[allow(clippy::type_complexity)]
-    let (map_min, map_max, cb_map_fn, tick_labels): (
+    let (map_min, map_max, cb_map_fn, tick_values): (
         f64,
         f64,
         MapFn,
-        Option<Vec<(f64, String)>>,
+        Option<Vec<(f64, f64)>>,
     ) = if hb.log_color {
         let log_max = (v_max - v_min + 1.0).max(1.0).log10().max(f64::EPSILON);
-        let mut ticks = vec![(0.0_f64, "0".to_string())];
+        let mut ticks = vec![(0.0_f64, 0.0_f64)];
         let mut k = 0u32;
         loop {
             let count = 10_f64.powi(k as i32);
             if count > v_max - v_min {
                 break;
             }
-            ticks.push(((count + 1.0).log10(), format!("{}", count as u64)));
+            ticks.push(((count + 1.0).log10(), count));
             k += 1;
         }
-        ticks.push((log_max, format!("{}", (v_max - v_min) as u64)));
+        ticks.push((log_max, v_max - v_min));
         ticks.dedup_by(|a, b| (a.0 - b.0).abs() < 1e-9);
         let lmax = log_max;
         (
@@ -17732,7 +17744,8 @@ fn add_hexbin_colorbar(hb: &HexbinPlot, scene: &mut Scene, computed: &ComputedLa
         min_value: map_min,
         max_value: map_max,
         label: Some(cb_label),
-        tick_labels,
+        tick_labels: None,
+        tick_values,
     };
     add_colorbar(&cb_info, scene, computed);
 }
@@ -18538,6 +18551,7 @@ fn add_treemap_colorbar(tm: &TreemapPlot, scene: &mut Scene, computed: &Computed
         max_value: v_max,
         label: Some(label),
         tick_labels: None,
+        tick_values: None,
     };
     add_colorbar(&cb_info, scene, computed);
 }
@@ -18979,6 +18993,7 @@ fn add_sunburst_colorbar(sb: &SunburstPlot, scene: &mut Scene, computed: &Comput
         max_value: v_max,
         label: Some(label),
         tick_labels: None,
+        tick_values: None,
     };
     add_colorbar(&cb_info, scene, computed);
 }

--- a/tests/colorbar_tick_format.rs
+++ b/tests/colorbar_tick_format.rs
@@ -1,0 +1,111 @@
+//! The log/count colorbar (hexbin and 2-D histogram with log colouring) must format
+//! its tick labels through `Layout::with_colorbar_tick_format`, just like the linear
+//! colorbar does. Previously these labels were hard-coded power-of-ten integers and the
+//! custom formatter was ignored.
+
+mod common;
+
+use kuva::backend::svg::SvgBackend;
+use kuva::plot::hexbin::HexbinPlot;
+use kuva::plot::histogram2d::Histogram2D;
+use kuva::render::layout::{Layout, TickFormat};
+use kuva::render::{plots::Plot, render::render_multiple};
+use std::sync::Arc;
+
+fn render_svg(plots: Vec<Plot>, layout: Layout) -> String {
+    SvgBackend.render_scene(&render_multiple(plots, layout))
+}
+
+/// SI-style integer formatter: 1000 → "1k", 10000 → "10k", 1_000_000 → "1M".
+fn si_format() -> TickFormat {
+    TickFormat::Custom(Arc::new(|v: f64| {
+        let n = v.round() as i64;
+        if n != 0 && n % 1_000_000 == 0 {
+            format!("{}M", n / 1_000_000)
+        } else if n != 0 && n % 1000 == 0 {
+            format!("{}k", n / 1000)
+        } else {
+            format!("{n}")
+        }
+    }))
+}
+
+/// One dense hex (`peak` coincident points) plus far-apart singletons that pin v_min at 1.
+fn make_hexbin_with_peak(peak: usize) -> Vec<Plot> {
+    let mut x = vec![2.5_f64; peak];
+    let mut y = vec![2.5_f64; peak];
+    for (sx, sy) in [(0.2, 0.2), (4.8, 0.3), (0.3, 4.7), (4.6, 4.8)] {
+        x.push(sx);
+        y.push(sy);
+    }
+    vec![Plot::Hexbin(
+        HexbinPlot::new().with_data(x, y).with_log_color(true),
+    )]
+}
+
+#[test]
+fn test_hexbin_log_colorbar_honors_custom_tick_format() {
+    // Peak 10001 → displayed counts run 1, 10, 100, 1000, 10000.
+    let plots = make_hexbin_with_peak(10001);
+    let layout = Layout::auto_from_plots(&plots)
+        .with_title("Hexbin SI colorbar")
+        .with_colorbar_tick_format(si_format());
+    let svg = render_svg(plots, layout);
+    common::write_test_output("test_outputs/colorbar_tick_format_hexbin_si.svg", &svg).unwrap();
+
+    assert!(svg.contains(">1k</text>"), "1000 should render as 1k");
+    assert!(svg.contains(">10k</text>"), "10000 should render as 10k");
+    assert!(
+        svg.contains(">100</text>"),
+        "100 stays 100 under the SI formatter"
+    );
+    assert!(
+        !svg.contains(">1000</text>"),
+        "raw 1000 must not appear once the SI formatter is applied"
+    );
+    assert!(
+        !svg.contains(">10000</text>"),
+        "raw 10000 must not appear once the SI formatter is applied"
+    );
+}
+
+/// Documents that the default (`TickFormat::Auto`) output is unchanged by the routing —
+/// integer count labels still render plain. (This passes with or without the fix, since
+/// Auto and the old `as u64` cast agree on integers; the fix itself is guarded by the
+/// custom-formatter tests above and below.)
+#[test]
+fn test_hexbin_log_colorbar_default_format_unchanged() {
+    let plots = make_hexbin_with_peak(10001);
+    let layout = Layout::auto_from_plots(&plots).with_title("Hexbin default colorbar");
+    let svg = render_svg(plots, layout);
+
+    assert!(
+        svg.contains(">10000</text>"),
+        "default Auto format keeps plain-integer count labels"
+    );
+}
+
+#[test]
+fn test_hist2d_log_colorbar_honors_custom_tick_format() {
+    // A single dense cell drives the count up so the log colorbar spans several decades.
+    let mut data: Vec<(f64, f64)> = vec![(5.0, 5.0); 1001];
+    data.extend([(0.5, 0.5), (9.5, 9.5)]);
+    let hist = Histogram2D::new()
+        .with_data(data, (0.0, 10.0), (0.0, 10.0), 10, 10)
+        .with_log_count();
+    let plots = vec![Plot::Histogram2d(hist)];
+    let layout = Layout::auto_from_plots(&plots)
+        .with_title("hist2d log sci colorbar")
+        .with_colorbar_tick_format(TickFormat::Sci);
+    let svg = render_svg(plots, layout);
+    common::write_test_output("test_outputs/colorbar_tick_format_hist2d_sci.svg", &svg).unwrap();
+
+    assert!(
+        svg.contains(">1e3</text>"),
+        "1000 should render in sci notation as 1e3"
+    );
+    assert!(
+        !svg.contains(">1000</text>"),
+        "raw 1000 must not appear once the Sci formatter is applied to the log colorbar"
+    );
+}


### PR DESCRIPTION
## Problem

The log-scale colorbar used by `HexbinPlot` and `Histogram2D` (with log colouring) generated its own hard-coded power-of-ten **integer** tick labels and ignored `Layout::with_colorbar_tick_format`. A caller supplying e.g. an SI `TickFormat::Custom` (to get `1k`, `10k`, `100k`) saw no effect — only the *linear* colorbar honoured the format, via `add_colorbar_at`'s auto-tick branch.

This looks like an oversight at introduction: `with_colorbar_tick_format` and `--log-count` were added in the same commit (`701230a`), but the log path was wired to emit pre-formatted `tick_labels` strings while only the auto-tick branch ran them through the formatter.

## Fix

Add a `tick_values: Option<Vec<(f64, f64)>>` field to `ColorBarInfo`, carrying `(position, raw-value)` pairs. `add_colorbar_at` formats the value through `colorbar_tick_format` at render time, taking precedence over the pre-formatted `tick_labels`. The hexbin (`add_hexbin_colorbar`) and 2-D histogram log colorbars now emit `tick_values` — positions stay in log space while labels show the raw counts.

Default `TickFormat::Auto` output is unchanged for integer count labels (the common case). One subtle improvement: for the unusual `log_color` + `Mean`/`Median` z-reduce combination the top tick now formats the real value (e.g. `7.3`) instead of the old `as u64` truncation (`7`).

## Tests

`tests/colorbar_tick_format.rs`:
- `test_hexbin_log_colorbar_honors_custom_tick_format` — SI formatter turns 1000/10000 into `1k`/`10k`; raw `1000`/`10000` absent.
- `test_hexbin_log_colorbar_default_format_unchanged` — Auto still emits plain `10000`.
- `test_hist2d_log_colorbar_honors_custom_tick_format` — `TickFormat::Sci` turns the 1000 count label into `1e3`.

`cargo test --features cli,full` and `cargo clippy --features cli,full -- -D warnings` pass. Existing `hist2d_svg.rs` colorbar-format tests (linear branch) still pass.

## Note for review

Adding `tick_values` to `ColorBarInfo` follows the existing precedent of the `tick_labels` field (also a `pub` field added without `#[non_exhaustive]`). If you'd prefer to close the door on future field-addition semver breaks, `#[non_exhaustive]` on `ColorBarInfo` would do it — happy to add that here or leave it as a separate call.

Part of a small series of independent colorbar fixes; touches the same `add_colorbar_at`/`colorbar_info` area as the data-max-tick PR (#91), so there may be light merge-order interplay.