### PR TITLE
A small handful of width fixes I missed on the first pass

### DIFF
--- a/src/bin/kuva/scatter3d.rs
+++ b/src/bin/kuva/scatter3d.rs
@@ -191,10 +191,10 @@ pub fn run(args: Scatter3DArgs) -> Result<(), String> {
             })
             .collect();
         if !entries.is_empty() {
-            let max_len = entries.iter().map(|e| e.label.len()).max().unwrap_or(0);
-            layout.show_legend = true;
-            layout.legend_width = (max_len as f64 * 8.5 + 35.0).max(80.0);
-            layout.legend_entries = Some(entries);
+            // Size the legend box to the measured group labels (swatch + gap + text)
+            // via the shared registration path, instead of a char-count width proxy
+            // with a fixed 80px floor that left dead space beside short labels.
+            layout = layout.with_legend_entries(entries);
         }
 
         let layout = apply_base_args(layout, &args.base);

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -1188,9 +1188,11 @@ impl Layout {
                 if pp.show_legend {
                     has_legend = true;
                     if pp.series.len() <= 1 {
-                        max_label_len = max_label_len
-                            .max(pp.left_label.len())
-                            .max(pp.right_label.len());
+                        // Single-series pyramids legend the two side labels. Measure both
+                        // so the box hugs their real width; a bare char count left
+                        // `max_label_w` at 0 and clipped labels like "Female".
+                        note_legend_label(&mut max_label_len, &mut max_label_w, &pp.left_label, 0);
+                        note_legend_label(&mut max_label_len, &mut max_label_w, &pp.right_label, 0);
                     } else {
                         for s in &pp.series {
                             note_legend_label(&mut max_label_len, &mut max_label_w, &s.label, 0);
@@ -2806,21 +2808,23 @@ impl ComputedLayout {
         // Width-aware colorbar geometry. Tick labels sit in a fixed band to the right of
         // the bar (governed by `colorbar_x_inset`), so the inset — not just the right
         // margin — must grow with the widest label or 6-digit labels clip at the canvas
-        // edge. Size to the widest label *after* applying the colorbar tick format,
-        // biasing low (no extra padding, 0.6 char-width) and letting `add_colorbar_at`
-        // shrink the font if a label still overruns. `colorbar_tick_values` is `None` for
-        // hand-built layouts; there we keep the legacy fixed reservation.
+        // edge. Measure the widest label *after* applying the colorbar tick format, at the
+        // size it renders (`tick_size`), and let `add_colorbar_at` shrink the font if a
+        // label still overruns. `colorbar_tick_values` is `None` for hand-built layouts;
+        // there we keep the legacy fixed reservation.
         let colorbar_label_px = match &layout.colorbar_tick_values {
-            Some(values) => {
-                let max_chars = values
-                    .iter()
-                    .map(|&v| layout.colorbar_tick_format.format(v).chars().count())
-                    .max()
-                    .unwrap_or(0);
+            Some(values) => values
+                .iter()
+                .map(|&v| {
+                    measure_text_width(
+                        &layout.colorbar_tick_format.format(v),
+                        tick_size,
+                        FontStyle::Regular,
+                    )
+                })
                 // Floor at ~2 char-widths like the axis-tick reservations, so a 1-2 char
                 // colorbar still gets a sane label band.
-                ((max_chars as f64) * tick_size * 0.6).max(tick_size * 2.0)
-            }
+                .fold(tick_size * 2.0, f64::max),
             None => 30.0 * s, // legacy ~5-char allotment
         };
         // bar (20) + tick mark + edge gap (10) + labels; equals the legacy 65*s inset


### PR DESCRIPTION
## Description

Sibling to the merged text-**width** work (#95).  Three width reservations still sized their boxes from `char-count` or `font_size × factor` proxies rather than measured text, so each mis-sized the box for its labels. This PR routes them through the same real-measurement path as the rest of the layout.

### What changed (symptom → cause)

- **scatter3d `--color-by` legend box over-wide** — the box left ~30 px of dead space beside
  short group labels (A/B/C). The `scatter3d` CLI set `legend_width = (chars × 8.5 + 35).max(80)`
  directly — a char-count proxy plus a hard 80 px floor — bypassing the content-based sizing.
  Now routes through the shared `Layout::with_legend_entries`, which measures the widest label.
  *Box 80 → 49 px, hugging the labels.*

- **pyramid `--legend` labels clip at the right edge** — "Female" ran past the box and canvas.
  The single-series branch in `auto_from_plots` updated the char-count accumulator but never the
  measured-width one (`max_label_w`), so it stayed 0 and the box fell back to a bare `0 + 40 = 40`
  px. Now measures both side labels via `note_legend_label`, exactly like the multi-series branch.
  *Box 40 → 84 px; "Female" sits fully inside the box and canvas.*

- **colorbar tick-label band** — the last width estimate #95 left un-migrated:
  `max_chars × tick_size × 0.6` in `ComputedLayout::from_layout`. The upstream colorbar-tick-format
  work (#91/#92) already plumbed `colorbar_tick_values` onto `Layout`, so this is a straight swap
  to `measure_text_width` per formatted label at the size it renders (`tick_size`), keeping the
  `tick_size × 2` floor. Corrects the mild **under**-reservation the low-biased `0.6` factor caused
  for long (6-digit) labels.

### Testing

- Full `--features cli,full` test suite passes; `clippy` clean (`-D warnings`).
- Verified each fix by rendering: the scatter3d box hugs A/B/C, the pyramid legend shows
  "Male"/"Female" fully inside the box and canvas, and a synthetic 6-digit colorbar
  (`200000`…`800000`) fits without clipping.
- The committed doc assets under `docs/src/assets/**` are **not** regenerated here (a few canvas widths shift → binary churn); left to the release flow.

### Note

Independent of the text-height PR — the two touch `layout.rs` only in disjoint regions and merge cleanly in either order (verified).

AI-assisted (Claude Code), human-supervised.

<!-- What does this PR do? Why? -->

## Type of change

- [ ] New plot type
- [ ] New feature / API addition
- [x] Bug fix
- [ ] Documentation / assets only
- [ ] Refactor / housekeeping

---

## Checklist

### Library (new plot type)
- [ ] `src/plot/<name>.rs` — struct + builder methods
- [ ] `src/plot/mod.rs` — `pub mod` + re-export
- [ ] `src/render/plots.rs` — `Plot` enum variant + `bounds()` / `colorbar_info()` / `set_color()`
- [ ] `src/render/render.rs` — `render_<name>()`, added to `render_multiple()` match, `skip_axes` if pixel-space
- [ ] `src/render/layout.rs` — `auto_from_plots()` extended if categories needed

### Tests
- [ ] New test file in `tests/` with ≥ basic render + SVG content + legend tests
- [x] `cargo test --features cli,full` — all existing tests still pass

### CLI (if applicable)
- [ ] `src/bin/kuva/<name>.rs` — Args struct (with `/// doc comment`) + `run()`
- [ ] `src/bin/kuva/main.rs` — module, Commands variant, match arm
- [ ] `scripts/smoke_tests.sh` — at least one invocation
- [ ] `tests/cli_basic.rs` — SVG output test + content verification test
- [ ] `docs/src/cli/index.md` — subcommand entry
- [ ] `man/kuva.1` — regenerated (`./target/debug/kuva man > man/kuva.1`)

### Documentation
- [ ] `examples/<name>.rs` — Rust example for doc asset generation
- [ ] `scripts/gen_docs.sh` — invocations added; `bash scripts/gen_docs.sh` runs clean
- [ ] `docs/src/plots/<name>.md` — documentation page with embedded SVGs
- [ ] `docs/src/SUMMARY.md` — link added
- [ ] `docs/src/gallery.md` — gallery card added
- [ ] `README.md` — plot types table updated

### Visual inspection
- [ ] Opened `test_outputs/` — new plot SVGs look correct
- [ ] Scanned neighbouring plots in `test_outputs/` for layout regressions
- [x] `bash scripts/smoke_tests.sh` — all existing smoke test outputs still look correct
- [x] No text clipped, no legend overlap, no spurious axes on pixel-space plots

### Housekeeping
- [ ] `CHANGELOG.md` — entry added under `## [Unreleased]`
- [ ] `README.md` — item marked done in TODO section if applicable
