### PR TITLE
Add multi-page PDF output (one scene per page)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multi-page PDF output** — `PdfBackend::render_scenes(&[&Scene])` and the one-shot `render_to_pdf_multi(pages)` render one kuva canvas per PDF page into a single document (like R's `pdf()` device, as used by fgbio/Picard reports). Each scene's SVG is embedded as a vector Form XObject via `svg2pdf::to_chunk` and the pages are assembled with `pdf-writer`, so nothing is rasterized. By default each page takes its scene's natural size; `PdfBackend::with_page_size(PageSize::inches(11.0, 8.5))` instead coerces every page to a fixed size, scaling each scene proportionally to fit and centering it. Fonts are subset and embedded per page (a limitation of the underlying `svg2pdf` conversion). Requires the `pdf` feature.
+
 ### Fixed
 
 - **`Scatter3D`/`Surface3D` instances combined in one panel now share one 3D coordinate box** — each instance previously called `data_ranges()`/drew its own wireframe box independently, so two `Scatter3D` (or a mix with `Surface3D`) in the same `render_multiple` call each normalized to their own min/max and could project completely different data onto identical screen coordinates, with the box itself drawn twice. `render_multiple` now computes one merged `DataRanges3D` and draws the box once, shared by every 3D instance in the call.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,7 @@ dependencies = [
  "fontdue",
  "image 0.24.9",
  "parquet",
+ "pdf-writer",
  "png 0.18.1",
  "rand",
  "rand_distr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ all-features = true
 [features]
 default    = []
 png        = ["dep:fontdue", "dep:png", "dep:flate2"]
-pdf        = ["dep:svg2pdf", "dep:flate2"]
+pdf        = ["dep:svg2pdf", "dep:pdf-writer", "dep:flate2"]
 embed_font = ["dep:flate2"]
 cli        = ["dep:clap", "dep:clap_mangen", "dep:csv"]
 full       = ["embed_font", "png", "pdf"]
@@ -52,6 +52,11 @@ parquet      = { version = "58.3", features = ["arrow"], optional = true }
 arrow-array  = { version = "58.3", optional = true }
 arrow-schema = { version = "58.3", optional = true }
 svg2pdf     = { version = "0.13", optional = true }
+# Used directly to assemble multi-page PDFs (one page per scene) by embedding
+# each SVG as a Form XObject via `svg2pdf::to_chunk`. svg2pdf does not re-export
+# pdf-writer, so keep this requirement in lockstep with svg2pdf's own pdf-writer
+# dependency — an incompatible bump there surfaces here as a build error.
+pdf-writer  = { version = "0.12", optional = true }
 clap        = { version = "4", features = ["derive"], optional = true }
 clap_mangen = { version = "0.2", optional = true }
 csv         = { version = "1", optional = true }

--- a/src/backend/pdf.rs
+++ b/src/backend/pdf.rs
@@ -1,7 +1,58 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use pdf_writer::{Content, Finish, Name, Pdf, Rect, Ref, TextStr};
+use svg2pdf::usvg;
+
 use crate::backend::svg::SvgBackend;
+use crate::render::color::Color;
 use crate::render::render::Scene;
 
-pub struct PdfBackend;
+/// Controls the page dimensions used when rendering a multi-page PDF with
+/// [`PdfBackend::render_scenes`].
+#[derive(Clone, Copy, Debug, Default)]
+pub enum PageSize {
+    /// Each page takes the natural pixel dimensions of its own scene, so pages
+    /// may differ in size. This is the default.
+    #[default]
+    Natural,
+    /// Every page is exactly `width` × `height` PDF points (1 pt = 1/72 inch).
+    /// Each scene is scaled uniformly to fit inside the page — preserving its
+    /// aspect ratio — and centered. Any leftover margin is filled with the
+    /// scene's background color when it resolves to a solid RGB value (a hex
+    /// code or a recognized named color); otherwise the margin is white.
+    Fixed { width: f64, height: f64 },
+}
+
+impl PageSize {
+    /// A fixed page size given in PDF points (1 pt = 1/72 inch).
+    ///
+    /// `width` and `height` must be finite and positive. Degenerate values are
+    /// rejected at render time by [`PdfBackend::render_scenes`]; in debug builds
+    /// they also trip an assertion here to surface the mistake at its source.
+    pub fn points(width: f64, height: f64) -> Self {
+        debug_assert!(
+            width.is_finite() && width > 0.0 && height.is_finite() && height > 0.0,
+            "PageSize dimensions must be finite and positive, got {width}×{height}"
+        );
+        Self::Fixed { width, height }
+    }
+
+    /// A fixed page size given in inches, e.g. `PageSize::inches(11.0, 8.5)` for
+    /// US Letter in landscape orientation.
+    pub fn inches(width: f64, height: f64) -> Self {
+        Self::points(width * 72.0, height * 72.0)
+    }
+}
+
+/// Vector PDF backend (requires feature `pdf`).
+///
+/// Single-scene output goes through [`svg2pdf::to_pdf`]; multi-page output
+/// embeds each scene's SVG as a Form XObject via [`svg2pdf::to_chunk`] and
+/// assembles the pages with `pdf-writer`.
+pub struct PdfBackend {
+    page_size: PageSize,
+}
 
 impl Default for PdfBackend {
     fn default() -> Self {
@@ -10,25 +61,28 @@ impl Default for PdfBackend {
 }
 
 impl PdfBackend {
-    pub fn new() -> Self {
-        Self
+    pub const fn new() -> Self {
+        Self {
+            page_size: PageSize::Natural,
+        }
     }
 
-    pub fn render_scene(&self, scene: &Scene) -> Result<Vec<u8>, String> {
-        let svg_str = SvgBackend.render_scene(scene);
+    /// Set the page size used by [`render_scenes`](Self::render_scenes) for
+    /// multi-page output. Defaults to [`PageSize::Natural`]. Single-scene
+    /// [`render_scene`](Self::render_scene) always uses the scene's natural size.
+    pub fn with_page_size(mut self, page_size: PageSize) -> Self {
+        self.page_size = page_size;
+        self
+    }
 
-        let mut fontdb = svg2pdf::usvg::fontdb::Database::new();
-        fontdb.load_font_data(crate::fonts::dejavu_sans().to_vec());
-        fontdb.load_font_data(crate::fonts::dejavu_sans_bold().to_vec());
-        fontdb.load_font_data(crate::fonts::dejavu_sans_oblique().to_vec());
-        fontdb.load_font_data(crate::fonts::dejavu_sans_mono().to_vec());
-        fontdb.load_system_fonts();
-        let options = svg2pdf::usvg::Options {
-            fontdb: std::sync::Arc::new(fontdb),
+    /// Render a single scene to a one-page PDF.
+    pub fn render_scene(&self, scene: &Scene) -> Result<Vec<u8>, String> {
+        let svg_str = SvgBackend::new().render_scene(scene);
+        let options = usvg::Options {
+            fontdb: Self::fontdb(),
             ..Default::default()
         };
-
-        let tree = svg2pdf::usvg::Tree::from_str(&svg_str, &options).map_err(|e| e.to_string())?;
+        let tree = usvg::Tree::from_str(&svg_str, &options).map_err(|e| e.to_string())?;
 
         svg2pdf::to_pdf(
             &tree,
@@ -37,4 +91,154 @@ impl PdfBackend {
         )
         .map_err(|e| e.to_string())
     }
+
+    /// Render one scene per page into a single multi-page PDF.
+    ///
+    /// Pages are laid out according to the backend's [`PageSize`]. Returns
+    /// `Err` if `scenes` is empty or if any scene fails to convert.
+    ///
+    /// Note: fonts are subset and embedded per page, a limitation of the
+    /// underlying `svg2pdf` conversion — documents with many pages will repeat
+    /// the (compressed) font subset once per page.
+    pub fn render_scenes(&self, scenes: &[Scene]) -> Result<Vec<u8>, String> {
+        if scenes.is_empty() {
+            return Err("at least one scene is required to render a PDF".to_string());
+        }
+        if let PageSize::Fixed { width, height } = self.page_size {
+            if !(width.is_finite() && width > 0.0 && height.is_finite() && height > 0.0) {
+                return Err(format!(
+                    "PageSize::Fixed requires finite, positive dimensions, got {width}×{height}"
+                ));
+            }
+        }
+
+        // Preserve the exact, well-tested single-page output for the common
+        // natural-sized single-scene case.
+        if scenes.len() == 1 {
+            if let PageSize::Natural = self.page_size {
+                return self.render_scene(&scenes[0]);
+            }
+        }
+
+        let options = usvg::Options {
+            fontdb: Self::fontdb(),
+            ..Default::default()
+        };
+        let conversion = svg2pdf::ConversionOptions::default();
+
+        let mut pdf = Pdf::new();
+        let mut alloc = Ref::new(1);
+        let catalog_id = alloc.bump();
+        let page_tree_id = alloc.bump();
+        let mut page_ids: Vec<Ref> = Vec::with_capacity(scenes.len());
+
+        for scene in scenes {
+            let svg_str = SvgBackend::new().render_scene(scene);
+            let tree = usvg::Tree::from_str(&svg_str, &options).map_err(|e| e.to_string())?;
+            let (chunk, svg_ref) =
+                svg2pdf::to_chunk(&tree, conversion).map_err(|e| e.to_string())?;
+
+            // Renumber the SVG's objects into this document's ref space. The
+            // chunk allocates from 1; map each to a fresh id past ours.
+            let mut remap = HashMap::new();
+            let chunk = chunk.renumber(|old| *remap.entry(old).or_insert_with(|| alloc.bump()));
+            let svg_ref = remap[&svg_ref];
+            pdf.extend(&chunk);
+
+            let page_id = alloc.bump();
+            let content_id = alloc.bump();
+            page_ids.push(page_id);
+
+            let (page_w, page_h, placement) = self.place(scene.width, scene.height);
+
+            // Content stream: optional background fill (only when letterboxing a
+            // fixed page), then place the SVG XObject.
+            let svg_name = Name(b"S1");
+            let mut content = Content::new();
+            if let PageSize::Fixed { .. } = self.page_size {
+                let [r, g, b] = page_background_rgb(scene);
+                content
+                    .set_fill_rgb(r, g, b)
+                    .rect(0.0, 0.0, page_w as f32, page_h as f32)
+                    .fill_nonzero();
+            }
+            content.transform(placement).x_object(svg_name);
+            let content_data = content.finish();
+            pdf.stream(content_id, &content_data);
+
+            let mut page = pdf.page(page_id);
+            page.media_box(Rect::new(0.0, 0.0, page_w as f32, page_h as f32));
+            page.parent(page_tree_id);
+            page.resources().x_objects().pair(svg_name, svg_ref);
+            page.contents(content_id);
+            page.finish();
+        }
+
+        pdf.catalog(catalog_id).pages(page_tree_id);
+        pdf.pages(page_tree_id)
+            .kids(page_ids.iter().copied())
+            .count(page_ids.len() as i32);
+
+        let info_id = alloc.bump();
+        pdf.document_info(info_id).producer(TextStr("kuva"));
+
+        Ok(pdf.finish())
+    }
+
+    /// Compute the page size (in points) and the content-stream placement
+    /// matrix for a scene of the given natural dimensions.
+    ///
+    /// The XObject produced by [`svg2pdf::to_chunk`] is a 1×1-point unit, so the
+    /// matrix both scales it to the drawn size and translates it into place.
+    fn place(&self, scene_w: f64, scene_h: f64) -> (f64, f64, [f32; 6]) {
+        match self.page_size {
+            PageSize::Natural => (
+                scene_w,
+                scene_h,
+                [scene_w as f32, 0.0, 0.0, scene_h as f32, 0.0, 0.0],
+            ),
+            PageSize::Fixed { width, height } => {
+                // Uniform scale-to-fit, then center (letterbox).
+                let scale = (width / scene_w).min(height / scene_h);
+                let draw_w = scene_w * scale;
+                let draw_h = scene_h * scale;
+                let tx = (width - draw_w) / 2.0;
+                let ty = (height - draw_h) / 2.0;
+                (
+                    width,
+                    height,
+                    [draw_w as f32, 0.0, 0.0, draw_h as f32, tx as f32, ty as f32],
+                )
+            }
+        }
+    }
+
+    /// Build the font database used to parse kuva SVGs into `usvg` trees. Loads
+    /// the bundled DejaVu variants (so text metrics match kuva's layout) plus
+    /// any system fonts.
+    fn fontdb() -> Arc<usvg::fontdb::Database> {
+        let mut db = usvg::fontdb::Database::new();
+        db.load_font_data(crate::fonts::dejavu_sans().to_vec());
+        db.load_font_data(crate::fonts::dejavu_sans_bold().to_vec());
+        db.load_font_data(crate::fonts::dejavu_sans_oblique().to_vec());
+        db.load_font_data(crate::fonts::dejavu_sans_mono().to_vec());
+        db.load_system_fonts();
+        Arc::new(db)
+    }
 }
+
+/// Resolve a scene's background color to RGB in `0.0..=1.0` for the page fill,
+/// defaulting to white when the background is unset or not a solid color.
+fn page_background_rgb(scene: &Scene) -> [f32; 3] {
+    match scene.background_color.as_deref().map(Color::from) {
+        Some(Color::Rgb(r, g, b)) => [r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0],
+        _ => [1.0, 1.0, 1.0],
+    }
+}
+
+// Backward-compat shim in the value namespace (mirrors `SvgBackend`).
+// `PdfBackend.render_scene(...)` resolves `PdfBackend` to this const;
+// `PdfBackend::new()` / `PdfBackend { .. }` resolve it to the type.
+// TODO: To phase out later: add #[deprecated(note = "Use PdfBackend::new()")] here.
+#[allow(non_upper_case_globals)]
+pub const PdfBackend: PdfBackend = PdfBackend::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub use backend::png::PngBackend;
 pub use backend::raster::RasterBackend;
 
 #[cfg(feature = "pdf")]
-pub use backend::pdf::PdfBackend;
+pub use backend::pdf::{PageSize, PdfBackend};
 
 pub use render::datetime::{ymd, ymd_hms, DateTimeAxis, DateUnit};
 /// KDE bandwidth via Silverman's rule of thumb: `h = 1.06 σ n^{-1/5}`.
@@ -186,4 +186,23 @@ pub fn render_to_pdf(
 ) -> Result<Vec<u8>, String> {
     let scene = render::render::render_multiple(plots, layout);
     backend::pdf::PdfBackend.render_scene(&scene)
+}
+
+/// Render several plot collections to a single multi-page PDF — one page per
+/// `(plots, layout)` pair — in one call (requires feature `pdf`).
+///
+/// Each page is sized to its own scene's natural dimensions. For fixed-size
+/// pages (e.g. US Letter), drive [`backend::pdf::PdfBackend`] directly with
+/// [`PdfBackend::with_page_size`](backend::pdf::PdfBackend::with_page_size).
+///
+/// Returns `Err(String)` if `pages` is empty or if any page fails to convert.
+#[cfg(feature = "pdf")]
+pub fn render_to_pdf_multi(
+    pages: Vec<(Vec<render::plots::Plot>, render::layout::Layout)>,
+) -> Result<Vec<u8>, String> {
+    let scenes: Vec<render::render::Scene> = pages
+        .into_iter()
+        .map(|(plots, layout)| render::render::render_multiple(plots, layout))
+        .collect();
+    backend::pdf::PdfBackend::new().render_scenes(&scenes)
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -200,7 +200,7 @@ pub use crate::render_to_svg;
 pub use crate::render_to_png;
 
 #[cfg(feature = "pdf")]
-pub use crate::render_to_pdf;
+pub use crate::{render_to_pdf, render_to_pdf_multi};
 
 // ── Backends ─────────────────────────────────────────────────────────────────
 pub use crate::backend::svg::SvgBackend;
@@ -210,4 +210,4 @@ pub use crate::backend::terminal::TerminalBackend;
 pub use crate::backend::png::PngBackend;
 
 #[cfg(feature = "pdf")]
-pub use crate::backend::pdf::PdfBackend;
+pub use crate::backend::pdf::{PageSize, PdfBackend};

--- a/tests/pdf_basic.rs
+++ b/tests/pdf_basic.rs
@@ -10,13 +10,32 @@ use kuva::render::figure::Figure;
 use kuva::render::layout::Layout;
 use kuva::render::plots::Plot;
 use kuva::render::render::render_scatter;
-use kuva::PdfBackend;
+use kuva::{PageSize, PdfBackend};
 
 fn make_scatter_scene() -> kuva::render::render::Scene {
     let data = vec![(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)];
     let plot = ScatterPlot::new().with_data(data).with_color("steelblue");
     let layout = Layout::new((0.0, 6.0), (0.0, 8.0)).with_title("PDF test");
     render_scatter(&plot, layout).with_background(Some("white"))
+}
+
+/// Count non-overlapping occurrences of `needle` in `haystack`.
+fn count(haystack: &[u8], needle: &[u8]) -> usize {
+    haystack
+        .windows(needle.len())
+        .filter(|w| *w == needle)
+        .count()
+}
+
+/// Each PDF page carries exactly one `/MediaBox`; the page tree carries none —
+/// so the count of `/MediaBox` markers is the page count.
+fn page_count(pdf: &[u8]) -> usize {
+    count(pdf, b"/MediaBox")
+}
+
+/// Whether `needle` appears anywhere in `haystack`.
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
 }
 
 #[test]
@@ -36,6 +55,176 @@ fn pdf_is_vector() {
     let bytes2 = PdfBackend::new().render_scene(&scene).unwrap();
     assert_eq!(&bytes1[..5], b"%PDF-", "first render is not a valid PDF");
     assert_eq!(&bytes2[..5], b"%PDF-", "second render is not a valid PDF");
+}
+
+#[test]
+fn render_scenes_rejects_empty_input() {
+    let result = PdfBackend::new().render_scenes(&[]);
+    assert!(result.is_err(), "empty scene list should be an error");
+}
+
+#[test]
+fn single_scene_matches_render_scene() {
+    let scene = make_scatter_scene();
+    let single = PdfBackend::new().render_scene(&scene).unwrap();
+    let multi = PdfBackend::new()
+        .render_scenes(std::slice::from_ref(&scene))
+        .unwrap();
+    assert_eq!(
+        single, multi,
+        "render_scenes of one natural-sized scene should equal render_scene"
+    );
+}
+
+#[test]
+fn two_scenes_produce_a_two_page_pdf() {
+    let a = make_scatter_scene();
+    let b = make_scatter_scene();
+    let bytes = PdfBackend::new()
+        .render_scenes(&[a, b])
+        .expect("render_scenes failed");
+    assert_eq!(&bytes[..5], b"%PDF-", "output is not a valid PDF");
+    assert_eq!(page_count(&bytes), 2, "expected two pages");
+    common::write_test_output("test_outputs/pdf_multipage_two.pdf", &bytes).unwrap();
+}
+
+#[test]
+fn three_scenes_produce_a_three_page_pdf() {
+    let a = make_scatter_scene();
+    let b = make_scatter_scene();
+    let c = make_scatter_scene();
+    let bytes = PdfBackend::new().render_scenes(&[a, b, c]).unwrap();
+    assert_eq!(page_count(&bytes), 3, "expected three pages");
+}
+
+#[test]
+fn fixed_page_size_coerces_every_page_to_us_letter() {
+    // Two scenes of different natural sizes, both coerced onto 11×8.5" pages.
+    let wide = make_scatter_scene();
+    let mut tall = make_scatter_scene();
+    tall.height *= 2.0;
+
+    let bytes = PdfBackend::new()
+        .with_page_size(PageSize::inches(11.0, 8.5))
+        .render_scenes(&[wide, tall])
+        .expect("fixed-size render failed");
+
+    assert_eq!(&bytes[..5], b"%PDF-", "output is not a valid PDF");
+    assert_eq!(page_count(&bytes), 2, "expected two pages");
+    // 11×8.5in = 792×612pt; both pages share that media box rect. The literal
+    // form (no decimal point) relies on pdf-writer's integer-valued-float
+    // formatting; pdf-writer is version-pinned, so this won't shift underfoot.
+    assert_eq!(
+        count(&bytes, b"[0 0 792 612]"),
+        2,
+        "both pages should be exactly US Letter landscape"
+    );
+    common::write_test_output("test_outputs/pdf_multipage_letter.pdf", &bytes).unwrap();
+}
+
+#[test]
+fn render_to_pdf_multi_smoke() {
+    let page1 = vec![Plot::Scatter(
+        ScatterPlot::new()
+            .with_data(vec![(1.0, 2.0), (3.0, 4.0)])
+            .with_color("steelblue"),
+    )];
+    let page2 = vec![Plot::Bar(
+        BarPlot::new().with_bar("A", 3.0).with_bar("B", 5.0),
+    )];
+    // page2's layout must be derived from page2's own plots (auto-ranged),
+    // computed before page2 is moved into the pages vec.
+    let layout1 = Layout::new((0.0, 6.0), (0.0, 8.0)).with_title("Page 1");
+    let layout2 = Layout::auto_from_plots(&page2).with_title("Page 2");
+    let bytes = kuva::render_to_pdf_multi(vec![(page1, layout1), (page2, layout2)])
+        .expect("render_to_pdf_multi failed");
+    assert_eq!(&bytes[..5], b"%PDF-");
+    assert_eq!(page_count(&bytes), 2);
+}
+
+#[test]
+fn natural_pages_preserve_each_scene_size_and_placement() {
+    // Distinct, clean dimensions so both the MediaBox and the content-stream
+    // placement matrix are exactly predictable.
+    let mut a = make_scatter_scene();
+    a.width = 320.0;
+    a.height = 240.0;
+    let mut b = make_scatter_scene();
+    b.width = 500.0;
+    b.height = 400.0;
+
+    let bytes = PdfBackend::new().render_scenes(&[a, b]).unwrap();
+    assert_eq!(page_count(&bytes), 2, "expected two pages");
+    // Each page takes its own scene's size, so pages differ in size.
+    assert!(contains(&bytes, b"[0 0 320 240]"), "page A media box");
+    assert!(contains(&bytes, b"[0 0 500 400]"), "page B media box");
+    // The 1×1-pt SVG XObject is scaled to the full scene size with no offset.
+    assert!(
+        contains(&bytes, b"320 0 0 240 0 0 cm"),
+        "page A placement matrix"
+    );
+    assert!(
+        contains(&bytes, b"500 0 0 400 0 0 cm"),
+        "page B placement matrix"
+    );
+}
+
+#[test]
+fn fixed_page_fill_uses_scene_background_color() {
+    // A non-white, RGB-resolvable background so the fill differs from the white
+    // fallback — proves the fill color is read from the scene, not defaulted.
+    let mut scene = make_scatter_scene();
+    scene.background_color = Some("#ff0000".to_string());
+
+    let bytes = PdfBackend::new()
+        .with_page_size(PageSize::inches(8.5, 11.0))
+        .render_scenes(&[scene])
+        .unwrap();
+
+    assert!(
+        contains(&bytes, b"1 0 0 rg"),
+        "letterbox fill should use the scene's red background, not white"
+    );
+}
+
+#[test]
+fn points_constructor_sets_exact_page_size() {
+    let scene = make_scatter_scene();
+    let bytes = PdfBackend::new()
+        .with_page_size(PageSize::points(300.0, 400.0))
+        .render_scenes(&[scene])
+        .unwrap();
+    assert!(
+        contains(&bytes, b"[0 0 300 400]"),
+        "media box should be 300×400 pt"
+    );
+}
+
+#[test]
+fn fixed_page_size_rejects_degenerate_dimensions() {
+    let scene = make_scatter_scene();
+    // Zero, negative, and non-finite page dimensions must error rather than
+    // emit a corrupt PDF. Built via the `Fixed` literal to bypass the
+    // debug-only assertion in the points/inches constructors.
+    for bad in [
+        PageSize::Fixed {
+            width: 0.0,
+            height: 400.0,
+        },
+        PageSize::Fixed {
+            width: -300.0,
+            height: 400.0,
+        },
+        PageSize::Fixed {
+            width: f64::NAN,
+            height: 400.0,
+        },
+    ] {
+        let result = PdfBackend::new()
+            .with_page_size(bad)
+            .render_scenes(std::slice::from_ref(&scene));
+        assert!(result.is_err(), "degenerate page size {bad:?} should error");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Description

Render a collection of kuva scenes into a single PDF, one canvas per page, for fgbio/Picard-style multi-page reports (similar to R's pdf() device).

- PdfBackend::render_scenes(&[Scene]) assembles pages by embedding each scene's SVG as a vector Form XObject (svg2pdf::to_chunk) and stitching them with pdf-writer; nothing is rasterized. Single-scene render_scene stays on the proven svg2pdf::to_pdf path.
- render_to_pdf_multi(pages) is the one-shot convenience entry point.
- PageSize::{Natural (default), Fixed} coerces every page to a fixed size (e.g. PageSize::inches(11.0, 8.5)), scaling each scene to fit and centering it; Fixed dimensions are validated at render time.

pdf-writer is added as a direct dependency (already present transitively via svg2pdf) and kept in lockstep with svg2pdf's own requirement.

Fonts are subset and embedded per page - a limitation of svg2pdf's public API that a future upstream change could remove.

I have not added new smoke tests or other niceties **yet**.  I wanted to float this PR first, make sure you're on board with it as a general thing, and then I'm happy to come back and add polish!

I also have two PRs open into `svg2pdf` that will, in the long term, make this a little nicer:

- https://github.com/typst/svg2pdf/pull/101 re-exports `pdf-writer` so kuva doesn't have to have a brittle copy of the dependency in Cargo.toml
- https://github.com/typst/svg2pdf/pull/102 provides a nicer API in svg2pdf that provides a single pass of font and color profile de-duplication over all the scenes, instead of embedding once per scene

## Type of change

- [ ] New plot type
- [x] New feature / API addition
- [ ] Bug fix
- [ ] Documentation / assets only
- [ ] Refactor / housekeeping

---

## Checklist

### Library (new plot type)
- [ ] `src/plot/<name>.rs` — struct + builder methods
- [ ] `src/plot/mod.rs` — `pub mod` + re-export
- [ ] `src/render/plots.rs` — `Plot` enum variant + `bounds()` / `colorbar_info()` / `set_color()`
- [ ] `src/render/render.rs` — `render_<name>()`, added to `render_multiple()` match, `skip_axes` if pixel-space
- [ ] `src/render/layout.rs` — `auto_from_plots()` extended if categories needed

### Tests
- [ ] New test file in `tests/` with ≥ basic render + SVG content + legend tests
- [x] `cargo test --features cli,full` — all existing tests still pass

### CLI (if applicable)
- [ ] `src/bin/kuva/<name>.rs` — Args struct (with `/// doc comment`) + `run()`
- [ ] `src/bin/kuva/main.rs` — module, Commands variant, match arm
- [ ] `scripts/smoke_tests.sh` — at least one invocation
- [ ] `tests/cli_basic.rs` — SVG output test + content verification test
- [ ] `docs/src/cli/index.md` — subcommand entry
- [ ] `man/kuva.1` — regenerated (`./target/debug/kuva man > man/kuva.1`)

### Documentation
- [ ] `examples/<name>.rs` — Rust example for doc asset generation
- [ ] `scripts/gen_docs.sh` — invocations added; `bash scripts/gen_docs.sh` runs clean
- [ ] `docs/src/plots/<name>.md` — documentation page with embedded SVGs
- [ ] `docs/src/SUMMARY.md` — link added
- [ ] `docs/src/gallery.md` — gallery card added
- [ ] `README.md` — plot types table updated

### Visual inspection
- [ ] Opened `test_outputs/` — new plot SVGs look correct
- [ ] Scanned neighbouring plots in `test_outputs/` for layout regressions
- [ ] `bash scripts/smoke_tests.sh` — all existing smoke test outputs still look correct
- [ ] No text clipped, no legend overlap, no spurious axes on pixel-space plots

### Housekeeping
- [x] `CHANGELOG.md` — entry added under `## [Unreleased]`
- [ ] `README.md` — item marked done in TODO section if applicable
